### PR TITLE
Added .of mock function for connecting channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 A mock to test the socket.io library implementation
+Forked and adapted to match my version of socketIO
 
 # Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A mock to test the socket.io library implementation
 
-# Installation 
+# Installation
 ```bash
 npm install socket-io-mock
 ```
@@ -15,7 +15,7 @@ Simply create new socket mock with:
 ```js
 var mockedSocket = new require('socket-io-mock')
 ```
-And use the socket as if it was a normal Socket.io socket. 
+And use the socket as if it was a normal Socket.io socket.
 
 For example:
 
@@ -26,11 +26,11 @@ var SocketMock = require('socket-io-mock')
 describe('Fast and isolated socket tests', function(){
   it('Sockets should be able to talk to each other without a server', function(done) {
     var socket = new SocketMock()
-    
+
     socket.on('message', function (message) {
       message.should.be.equal('Hello World!')
     })
-    socket.emit('message', 'Hello World!')
+    socket.socketClient.emit('message', 'Hello World!')
   })
 })
 ```

--- a/index.js
+++ b/index.js
@@ -58,6 +58,13 @@ function SocketClient(socketMock) {
 
         socketMock.emit(eventKey, payload);
     }
+
+    /**
+     * Volatile messages
+     *
+     */
+    this.volatile = {}
+    this.volatile.emit = this.emit
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -48,8 +48,11 @@ function SocketClient(socketMock) {
         }
     }
 
+    /**
+     * Broadcast to all others players
+     * As we are the only one, its actually do nothing
+     */
     this.broadcast = function(eventKey, payload) {
-        // It should emit to all others user, but we are the only one so dont emit
         return;
 
         socketMock.emit(eventKey, payload);
@@ -67,6 +70,21 @@ function SocketMock () {
 
     // self assign, for avoiding this clashing with objects
     var self = this
+
+
+    /**
+     * Emit 'connect' event with correct socket
+     */
+    this.connectClient = function() {
+
+        var eventKey = 'connect';
+
+        if (this.eventCallbacks[eventKey]) {
+            debug("Connecting client socket")
+
+            this.eventCallbacks[eventKey](this.socketClient)
+        }
+    }
 
     /**
      * Emit an event to the server (used by client)

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ function SocketClient(socketMock) {
      * Broadcast to all others players
      * As we are the only one, its actually do nothing
      */
-    this.broadcast = function(eventKey, payload) {
+    this.broadcast = {}
+    this.broadcast.emit = function(eventKey, payload) {
         return;
 
         socketMock.emit(eventKey, payload);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function SocketClient(socketMock) {
      */
     this.on = function(eventKey, callback) {
         this.eventCallbacks[eventKey] = callback
-    } 
+    }
 
     /**
      * Emit an event to the server client
@@ -29,6 +29,7 @@ function SocketClient(socketMock) {
      * @param  {function} callback
      */
     this.emit = function(eventKey, payload, callback) {
+        payload = payload || null;
         callback = callback || function() { return true }
         callback(socketMock.emitEvent(eventKey, payload))
     }
@@ -44,7 +45,7 @@ function SocketClient(socketMock) {
         if (typeof this.eventCallbacks[eventKey] === 'function') {
             debug("Event %s on client side is dispatched with payload %s", eventKey, JSON.stringify(payload))
             this.eventCallbacks[eventKey](payload)
-        }   
+        }
     }
 }
 
@@ -89,6 +90,7 @@ function SocketMock () {
      * @param  {object} payload -- Additional payload
      */
     this.emit = function(eventKey, payload) {
+        payload = payload || null;
         if (typeof doneCallback === 'function') {
             doneCallback(self.socketClient.emit(eventKey, createPayload(payload)))
         }
@@ -113,7 +115,7 @@ function SocketMock () {
     this.broadcast.to = function(roomKey) {
         return {
             /**
-             * Emitting 
+             * Emitting
              * @param  {[type]} eventName [description]
              * @param  {[type]} payload   [description]
              */
@@ -147,6 +149,14 @@ function SocketMock () {
      */
     this.monitor = function(value) {
         debug("Monitor: %s", value)
+    }
+
+    /**
+     * Accept connecting to a channel, but all messages goes to all channels
+     * @param  {string} name of the channel (useless)
+     */
+    this.of = function(value) {
+        return this;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -47,13 +47,19 @@ function SocketClient(socketMock) {
             this.eventCallbacks[eventKey](payload)
         }
     }
+
+    this.broadcast = function(eventKey, payload) {
+        // It should emit to all others user, but we are the only one so dont emit
+        return;
+
+        socketMock.emit(eventKey, payload);
+    }
 }
 
 /**
  * A mocking class for the Socket IO Server side
  */
 function SocketMock () {
-    this.broadcast = {}
     this.joinedRooms = []
     this.eventCallbacks = {}
     this.socketClient = new SocketClient(this)
@@ -109,23 +115,11 @@ function SocketMock () {
     }
 
     /**
-     * Broadcast to room
+     * Broadcast to everybody
+     * Since only one client connected, equivalent to emit
      * @param  {string} roomKey the roomkey which need to be attached to
      */
-    this.broadcast.to = function(roomKey) {
-        return {
-            /**
-             * Emitting
-             * @param  {[type]} eventName [description]
-             * @param  {[type]} payload   [description]
-             */
-            emit: function(eventKey, payload) {
-                if (self.generalCallbacks[eventKey]) {
-                    self.generalCallbacks[eventKey](createPayload(payload), roomKey)
-                }
-            }
-        }
-    }
+    this.broadcast = this.emit
 
     /**
      * Joining a room

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-mock",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "a mocked version of a socket.io socket for testing",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-mock",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "a mocked version of a socket.io socket for testing",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "chai": "^2.2.0",
     "debug": "^2.1.3",
     "mocha": "^2.2.4"
+  },
+  "devDependencies": {
+    "socket-io-mock": "git://github.com/pakokrew/socket-io-mock.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-mock",
-  "version": "1.0.4",
+  "version": "1.0.41",
   "description": "a mocked version of a socket.io socket for testing",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-mock",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "a mocked version of a socket.io socket for testing",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-mock",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "a mocked version of a socket.io socket for testing",
   "main": "index.js",
   "scripts": {

--- a/test/socket.js
+++ b/test/socket.js
@@ -11,6 +11,17 @@ describe('Utils: Socket', function(){
     done()
   })
 
+  it('should connect server and client with socket', function(done){
+    socket.on("connect", function(socketClient) {
+
+      socketClient.should.be.equal(socket.socketClient)
+
+      done()
+    })
+
+    socket.connectClient()
+  })
+
   it('should fire event on the server side when on() is assigned', function(done){
     socket.on("test", function(payload) {
       payload.should.have.property('never')

--- a/test/socket.js
+++ b/test/socket.js
@@ -55,6 +55,16 @@ describe('Utils: Socket', function(){
     socket.emit("test", eventPayload)
   })
 
+  it('should broadcast event to all clients', function(done) {
+    socket.socketClient.on("test", function(payload) {
+      payload.should.be.equal("hello")
+
+      done()
+    })
+
+    socket.broadcast("test", "hello")
+  })
+
   it('Should add a room to `joinedRooms` when join() is called', function(done) {
 
     socket.join(roomKey)
@@ -72,24 +82,5 @@ describe('Utils: Socket', function(){
     socket.joinedRooms.should.have.length(0)
 
     done()
-  })
-  it('Should fire `onEmit()` callback when a event is fired in the room', function(done) {
-
-    socket.join(roomKey)
-
-    var eventPayload = {
-      "test": "123"
-    }
-
-    socket.onEmit('test', function(payload, roomEvent) {
-      roomEvent.should.be.equal(roomKey)
-
-      payload.should.have.property("test")
-      payload.test.should.be.equal("123")
-
-      done()
-    })
-
-    socket.broadcast.to(roomKey).emit('test', eventPayload)
   })
 })

--- a/test/socket.js
+++ b/test/socket.js
@@ -10,6 +10,7 @@ describe('Utils: Socket', function(){
     socket = new SocketMock()
     done()
   })
+
   it('should fire event on the server side when on() is assigned', function(done){
     socket.on("test", function(payload) {
       payload.should.have.property('never')
@@ -26,6 +27,14 @@ describe('Utils: Socket', function(){
     })
 
     socket.socketClient.emit("test", eventPayload)
+  })
+
+  it('should accept empty payload', function(done){
+    socket.on("test", function() {
+      done()
+    })
+
+    socket.socketClient.emit("test")
   })
 
   it('should fire event on the client side when on() is assigned', function(done) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -76,6 +76,11 @@ describe('Utils: Socket', function(){
     socket.broadcast("test", "hello")
   })
 
+  it('client could broadcast to others clients', function() {
+
+    socket.socketClient.broadcast.emit("test", "hello")
+  })
+
   it('Should add a room to `joinedRooms` when join() is called', function(done) {
 
     socket.join(roomKey)


### PR DESCRIPTION
My server code uses channels and the function .of() for selecting one, which is not implemented here. I mocked it, but didn't write the functional. 
For testing purposes it is ok, but if you want channels to work I can make it.
